### PR TITLE
read xcompact files without renaming them first

### DIFF
--- a/aftle/barrierField.cpl
+++ b/aftle/barrierField.cpl
@@ -22,11 +22,9 @@ INTEGER iF = nfmin
 ! 
 LOOP WHILE {[IF dir>0 THEN nfmax ELSE iF]-[IF dir>0 THEN iF ELSE nfmax]}>0 
    IF iF=nfmin THEN
-      fieldname = WRITE(path"Field"iF".fld")
-      readVelocityField(fieldname, velocity(*,*,*,imod(iF)), active(*,*,*,imod(iF)))
+      readVelocityField(iF, velocity(*,*,*,imod(iF)), active(*,*,*,imod(iF)))
    END IF
-   STRING fieldname = WRITE(path"Field"iF+dir".fld")
-   readVelocityField(fieldname, velocity(*,*,*,imod(iF+dir)), active(*,*,*,imod(iF+dir)))
+   readVelocityField(iF+dir, velocity(*,*,*,imod(iF+dir)), active(*,*,*,imod(iF+dir)))
    REAL chron=wallclock(); IF has_terminal THEN WRITE "Advances trajectories..."
    LOOP FOR it=1 TO ODE(*,1).LENGTH
      REAL chroni=wallclock(); IF has_terminal THEN WRITE " ", "ODE step ",it

--- a/aftle/channelInterface.cpl
+++ b/aftle/channelInterface.cpl
@@ -1,6 +1,6 @@
 ! this module should provide only an interaface to a subroutine that can read
 ! flow snapshots and return the velocity field in physical space 
-SUBROUTINE readVelocityField(STRING field_name; POINTER TO ARRAY(*,*,*) OF REALVEL Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr) FOLLOWS
+SUBROUTINE readVelocityField(INTEGER field_id; POINTER TO ARRAY(*,*,*) OF REALVEL Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr) FOLLOWS
 
 MODULE channelInterface
 INTEGER nxdF=nxd DIV 2
@@ -115,7 +115,8 @@ PARALLEL LOOP FOR ismp=0 TO nsmp-1
 REPEAT
 END vetaTOuvw
 
-SUBROUTINE read_field(STRING field_name; POINTER TO ARRAY(*,*,*) OF VELOCITY V)
+SUBROUTINE read_field(INTEGER field_id; POINTER TO ARRAY(*,*,*) OF VELOCITY V)
+  STRING field_name = WRITE(path"Field"field_id".fld")
   IF has_terminal THEN WRITE "Reading velocity field:", field_name
   clock = wallclock()
   diskfield=OPEN(field_name)
@@ -132,10 +133,10 @@ SUBROUTINE read_field(STRING field_name; POINTER TO ARRAY(*,*,*) OF VELOCITY V)
   IF has_terminal THEN WRITE " ","took "-clock+wallclock() " seconds"
 END read_field
 
-SUBROUTINE readVelocityField(STRING field_name; POINTER TO ARRAY(*,*,*) OF REALVEL  Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr)
+SUBROUTINE readVelocityField(INTEGER field_id; POINTER TO ARRAY(*,*,*) OF REALVEL  Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr)
   SHARED ARRAY(0..nx,-nz..nz,-1..ny+1) OF VELOCITY V
   ! Load velocity field
-  read_field(field_name,V)
+  read_field(field_id,V)
   ! Compute active field
   SHARED ARRAY(0..nx,-nz..nz,-1..ny+1) OF VELOCITY field=0
 #ifdef vorticity

--- a/aftle/xCompactInterface.cpl
+++ b/aftle/xCompactInterface.cpl
@@ -16,7 +16,7 @@
 ! momentum and vorticity. submitted (2020)
 ! 
 
-SUBROUTINE readVelocityField(STRING field_name; POINTER TO ARRAY(*,*,*) OF REALVEL Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr) FOLLOWS
+SUBROUTINE readVelocityField(INTEGER field_id; POINTER TO ARRAY(*,*,*) OF REALVEL Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr) FOLLOWS
 
 MODULE channelInterface
 
@@ -24,7 +24,11 @@ POINTER TO STORED STRUCTURE(
   ARRAY(0..2,0..nzd-1,0..ny,0..nxd-1) OF REAL fieldimage
   ) diskfield
 
-SUBROUTINE read_field(STRING field_name; POINTER TO ARRAY(*,*,*) OF REALVEL V)
+SUBROUTINE read_field(INTEGER field_id; POINTER TO ARRAY(*,*,*) OF REALVEL V)
+  DEFAULTFORMAT 1.7
+
+  WRITE BY NAME field_id
+  STRING field_name = WRITE(path"/restart"field_id)
   IF has_terminal THEN WRITE "Reading velocity field:", field_name
   clock = wallclock()
   diskfield=OPEN(field_name)
@@ -177,9 +181,9 @@ DO WRITE testdf(i), 2*y(i), testd2f(i), 2 FOR i=0 TO ny
 STOP
 !)
 
-SUBROUTINE readVelocityField(STRING field_name; POINTER TO ARRAY(*,*,*) OF REALVEL  Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr)
+SUBROUTINE readVelocityField(INTEGER field_id; POINTER TO ARRAY(*,*,*) OF REALVEL  Vr; POINTER TO ARRAY(*,*,*) OF REALAVF  AVFr)
   ! Load velocity field
-  read_field(field_name,Vr)
+  read_field(field_id,Vr)
   ! Compute active field
   ! XXX SHARED ARRAY(0..nx,-nz..nz,-1..ny+1) OF VELOCITY field=0
 #ifdef vorticity


### PR DESCRIPTION
I moved the logic for determining the file name in the respective interfaces. 